### PR TITLE
Makes the host name argument optional

### DIFF
--- a/sshfpgen
+++ b/sshfpgen
@@ -3,12 +3,11 @@
 # Creates SSHFP Records vor all available keys
 #
 
-HOST="$1"
-
 if (($# < 1))
 then
-  echo "Usage: sshfpgen <hostname>"
-  exit 1
+  HOST=$(hostname -f)
+else
+  HOST="$1"
 fi
 
 for pubkey in /etc/ssh/ssh_host_*_key.pub


### PR DESCRIPTION
If the host name argument is not present, use "hostname -f" instead.