### PR TITLE
BSD compatibility

### DIFF
--- a/sshfpgen
+++ b/sshfpgen
@@ -10,25 +10,41 @@ then
   echo "Usage: sshfpgen <hostname>"
 fi
 
-for pubkey in /etc/ssh/ssh_host_*_key.pub
+if which openssl >/dev/null 2>&1
+then
+  if ! which sha1sum >/dev/null 2>&1
+  then
+    sha1sum() {
+      openssl dgst -sha1 $*
+    }
+  fi
+  if ! which sha256sum >/dev/null 2>&1
+  then
+    sha256sum() {
+      openssl dgst -sha256 $*
+    }
+  fi
+fi
+
+for pubkey in /etc/ssh/ssh_host_*_key.pub /etc/ssh_host_*_key.pub
 do
   case "$(cut -d _ -f3 <<< "$pubkey")"
   in
     rsa)
-      echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
     ;;
     dsa)
-      echo "$HOST IN SSHFP 2 1 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 2 2 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 2 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 2 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
     ;;
     ecdsa)
-      echo "$HOST IN SSHFP 3 1 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 3 2 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 3 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 3 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
     ;;
     ed25519)
-      echo "$HOST IN SSHFP 4 1 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 -d | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 4 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
     ;;
   esac
 done


### PR DESCRIPTION
On *BSD systems (including MacOS X):
-   SSH server key files are in `/etc/` not `/etc/ssh/` - look there as well
-   `base64` command `-d` option is debug (Linux and BSD `base64` both support `--decode`)
-   `sha1sum` and `sha256sum` may not be present (but openssl provides same functionality)