### PR TITLE
restore BSD compatibility for older OpenSSL

### DIFF
--- a/sshfpgen
+++ b/sshfpgen
@@ -12,16 +12,18 @@ fi
 
 if which openssl >/dev/null 2>&1
 then
+  # openssl version only works the same as coreutils for stdin
+  # unless the -r option is given; but older openssl on some BSD lack it
   if ! which sha1sum >/dev/null 2>&1
   then
     sha1sum() {
-      openssl dgst -sha1 -r $*
+      openssl dgst -sha1
     }
   fi
   if ! which sha256sum >/dev/null 2>&1
   then
     sha256sum() {
-      openssl dgst -sha256 -r $*
+      openssl dgst -sha256
     }
   fi
 fi


### PR DESCRIPTION
TL;DR: openssl version only works the same as coreutils for stdin
unless the -r option is given; but older openssl on some BSD lack it

```
$ openssl version
OpenSSL 0.9.8zd 8 Jan 2015
$ openssl dgst -sha1 <<<foobar
988881adc9fc3655077dc2d4d757d480b5ea0e11
$ openssl dgst -sha1 -r <<<foobar
unknown option '-r'
options are
-c              to output the digest with separating colons
...
```

Since the script only uses `sha1sum` and `sha256sum` on stdin (without arguments) and the openssl output is compatible with coreutils version in that case even without the `-r` option, it seems better to just define the bash functions without any arguments (removed $*) or the `-r` option, and to document the reason for this.