### PR TITLE
SSHFP DNS record improvements

### DIFF
--- a/sshfpgen
+++ b/sshfpgen
@@ -31,20 +31,20 @@ do
   case "$(cut -d _ -f3 <<< "$pubkey")"
   in
     rsa)
-      echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]'"
+      echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
     ;;
     dsa)
-      echo "$HOST IN SSHFP 2 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 2 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 2 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
+      echo "$HOST IN SSHFP 2 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
     ;;
     ecdsa)
-      echo "$HOST IN SSHFP 3 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 3 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 3 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
+      echo "$HOST IN SSHFP 3 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
     ;;
     ed25519)
-      echo "$HOST IN SSHFP 4 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
-      echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 4 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
+      echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
     ;;
   esac
 done


### PR DESCRIPTION
Convert the checksums to uppercase.
Split longer DNS records in multiple parts.