### PR TITLE
Removed split in SHA256 record

### DIFF
--- a/sshfpgen
+++ b/sshfpgen
@@ -31,7 +31,7 @@ do
   case "$(cut -d _ -f3 <<< "$pubkey")"
   in
     rsa)
-      echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]'"
+      echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
       echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
     ;;
     dsa)

--- a/sshfpgen
+++ b/sshfpgen
@@ -32,19 +32,20 @@ do
   in
     rsa)
       echo "$HOST IN SSHFP 1 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
-      echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
+      echo "$HOST IN SSHFP 1 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
     ;;
     dsa)
       echo "$HOST IN SSHFP 2 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
-      echo "$HOST IN SSHFP 2 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
+      echo "$HOST IN SSHFP 2 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
     ;;
     ecdsa)
       echo "$HOST IN SSHFP 3 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
-      echo "$HOST IN SSHFP 3 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
+      echo "$HOST IN SSHFP 3 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
     ;;
     ed25519)
       echo "$HOST IN SSHFP 4 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
-      echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]' | sed -e "s/\([0-9A-Z]\{56\}\)/\1 /")"
+      echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ' | tr '[:lower:]' '[:upper:]')"
     ;;
   esac
 done
+


### PR DESCRIPTION
As told by RFC4255 section 3.1.3

>    The message-digest algorithm is presumed to produce an opaque octet
>   string output, which is placed as-is in the RDATA fingerprint field.

and in section 3.2:

>   The RDATA of the presentation format of the SSHFP resource record
>   consists of two numbers (algorithm and fingerprint type) followed by
>   the fingerprint itself, presented in hex, e.g.:
>
>       host.example.  SSHFP 2 1 123456789abcdef67890123456789abcdef67890
>
>   The use of mnemonics instead of numbers is not allowed.

Using spaces would only make sense if the entire value were longer than 255 bytes as mentioned in RFC4408 section 3.1.3:

>   As defined in [RFC1035] sections 3.3.14 and 3.3, a single text DNS
>   record (either TXT or SPF RR types) can be composed of more than one
>   string.  If a published record contains multiple strings, then the
>   record MUST be treated as if those strings are concatenated together
>   without adding spaces.  For example:
>
>      IN TXT "v=spf1 .... first" "second string..."
>
>   MUST be treated as equivalent to
>
>      IN TXT "v=spf1 .... firstsecond string..."
>
>   SPF or TXT records containing multiple strings are useful in
>   constructing records that would exceed the 255-byte maximum length of
>   a string within a single TXT or SPF RR record.

Therefore i am removing that space here.