### PR TITLE
Added Ed448 to sshfpgen

### DIFF
--- a/sshfpgen
+++ b/sshfpgen
@@ -46,6 +46,10 @@ do
       echo "$HOST IN SSHFP 4 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
       echo "$HOST IN SSHFP 4 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
     ;;
+    ed448)
+      echo "$HOST IN SSHFP 6 1 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha1sum  | cut -f 1 -d ' ')"
+      echo "$HOST IN SSHFP 6 2 $(cut -f2 -d ' ' "$pubkey" | base64 --decode | sha256sum  | cut -f 1 -d ' ')"
+    ;;
   esac
 done
 


### PR DESCRIPTION
Ed448 is available as an SSHFP RR type for public key algorithms with the value "6" according to https://www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.xhtml#dns-sshfp-rr-parameters-1 and https://is.gd/dWb0Ow.